### PR TITLE
Fix malformed bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,6 @@
     "inuit-headings": "~0.2.2",
     "inuit-page": "~0.2.1",
     "inuit-lists": "~0.1.0",
-    "inuit-images": "~0.3.2",
+    "inuit-images": "~0.3.2"
   }
 }


### PR DESCRIPTION
`bower install` will not work, as it expects JSON, and the dependencies list ends with a `,`.

`bower` (and `npm`) require JSON with no trailing comma on the final item in an object/array.

---

As a separate (but related) issue, all of the dependencies managed by `bower` and `npm` are committed. Typically, they are included in a build step (although I don't know the system, so I won't say it is wrong). By committing them, you obviate the need for `npm` and `bower` in your install instructions, in the README, and it makes the README a bit more confusing.

I'm still just reading through the docs, and so I'm not sure if this belongs in an issue or Worklist. LMK and I'd be glad to move it over.